### PR TITLE
Added a "Template Path" setting

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,16 +17,26 @@ Coming soon...
 Macro Kit can be used within your templates simply by importing all of the macros into a template.
 
 ```
-{% import "macrokit/all" as mk %}
+{% import "_macrokit/all" as mk %}
 ```
 
 Or import individual macros into the current namespace.
 
 ```
-{% from "macrokit/all" import daterange, randomString %}
+{% from "_macrokit/all" import daterange, randomString %}
 {{ daterange(event.start, event.end) }}
 {{ randomString(10) }}
 ```
+
+You can customize the path to the `all.twig` template (`_macrokit` by default) by editing the plugin’s “Template Path” setting, or creating a `config/macro-kit.php` file with this:
+
+```php
+<?php
+
+return [
+    'templatePath' => '_customTemplatePath',
+];
+``` 
 
 ### abbrStateName
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,15 +1,28 @@
 <?php
 namespace timknight\macrokit;
 
+use Craft;
 use craft\events\RegisterTemplateRootsEvent;
 use craft\web\View;
 use yii\base\Event;
+use yii\helpers\StringHelper;
 
 /**
  * Macro Kit Plugin
+ *
+ * @property-read Settings $settings
+ * @method Settings getSettings()
  */
 class Plugin extends \craft\base\Plugin
 {
+    /**
+     * @inheritdoc
+     */
+    public $hasCpSettings = true;
+
+    /**
+     * @inheritdoc
+     */
     public function init()
     {
         parent::init();
@@ -18,8 +31,43 @@ class Plugin extends \craft\base\Plugin
             View::class,
             View::EVENT_REGISTER_SITE_TEMPLATE_ROOTS,
             function(RegisterTemplateRootsEvent $event) {
-                $event->roots['macrokit'] = __DIR__ . '/macros';
+                $event->roots[$this->settings->templatePath] = __DIR__ . '/macros';
             }
         );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function createSettingsModel()
+    {
+        return new Settings();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function settingsHtml()
+    {
+        $privateTemplateTrigger = Craft::$app->config->general->privateTemplateTrigger;
+
+        if (!StringHelper::startsWith($this->settings->templatePath, $privateTemplateTrigger)) {
+            $tip = Craft::t('macro-kit', 'Beginning with {trigger} is recommended.', [
+                'trigger' => "`{$privateTemplateTrigger}`",
+            ]);
+        }
+
+        return Craft::$app->view->renderTemplateMacro('_includes/forms', 'textField', [
+            [
+                'first' => true,
+                'name' => 'templatePath',
+                'id' => 'template-path',
+                'value' => $this->settings->templatePath,
+                'label' => Craft::t('macro-kit', 'Template Path'),
+                'instructions' => Craft::t('macro-kit', 'The template path that `all.twig` should be accessible by.'),
+                'tip' => $tip ?? null,
+                'errors' => $this->settings->getErrors('templatePath'),
+            ]
+        ]);
     }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -1,0 +1,34 @@
+<?php
+namespace timknight\macrokit;
+
+use craft\base\Model;
+use yii\validators\InlineValidator;
+
+/**
+ * Macro Kit settings
+ */
+class Settings extends Model
+{
+    /**
+     * @var string The template path that `all.twig` should be accessible by
+     */
+    public $templatePath = '_macrokit';
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        $rules = parent::rules();
+        $rules[] = ['templatePath', 'trim'];
+        $rules[] = ['templatePath', 'required'];
+        $rules[] = ['templatePath', function($attribute, $params, InlineValidator $validator) {
+            $this->templatePath = trim($this->templatePath, '/');
+            if (!preg_match('/^[\w\/\-]+$/', $this->templatePath)) {
+                $validator->addError($this, $attribute, '{attribute} is not a valid template path.');
+            }
+        }];
+
+        return $rules;
+    }
+}


### PR DESCRIPTION
This makes the template root name customizable, and it's now `_macrokit` by default (instead of `macrokit`), so the templates inside aren’t publicly-accessible by direct HTTP requests.